### PR TITLE
Increasing memory allocation in yarn-site.xml

### DIFF
--- a/config/yarn-site.xml
+++ b/config/yarn-site.xml
@@ -18,6 +18,14 @@
         <name>yarn.resourcemanager.hostname</name>
         <value>mycluster-master</value>
     </property>
+    <property>
+        <name>yarn.scheduler.maximum-allocation-mb</name>
+        <value>65536</value> <!-- 64GB -->
+    </property>
+    <property>
+        <name>yarn.nodemanager.resource.memory-mb</name>
+        <value>65536</value> <!-- 64GB -->
+    </property>
 
 <property>
     <name>yarn.resourcemanager.scheduler.address</name>


### PR DESCRIPTION
Added yarn.scheduler.maximum-allocation-mb and yarn.nodemanager.resource.memory-mb properties with 65536 MB values - 64 GB